### PR TITLE
Quality: Sass variable typo breaks text color generation

### DIFF
--- a/scss/core/_global.scss
+++ b/scss/core/_global.scss
@@ -7,7 +7,7 @@
         background-color: $color_value !important;
       }
       .#{$color_name}-text {
-        color: $color-value !important;
+        color: $color_value !important;
       }
       .rgba-#{$color_name}-slight,
       .rgba-#{$color_name}-slight:after {


### PR DESCRIPTION
## Problem

In the global color utility loop, the `.#{color_name}-text` class uses `$color-value` instead of `$color_value`. This is a different identifier and can cause Sass compilation errors or missing color utility output.

**Severity**: `high`
**File**: `scss/core/_global.scss`

## Solution

Replace `color: $color-value !important;` with `color: $color_value !important;` and run Sass compilation to verify generated utility classes.

## Changes

- `scss/core/_global.scss` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
